### PR TITLE
Allows tenant changes to resources by setting option.

### DIFF
--- a/lib/acts_as_tenant/model_extensions.rb
+++ b/lib/acts_as_tenant/model_extensions.rb
@@ -129,13 +129,15 @@ module ActsAsTenant
         to_include = Module.new do
           define_method "#{fkey}=" do |integer|
             write_attribute("#{fkey}", integer)
-            raise ActsAsTenant::Errors::TenantIsImmutable if send("#{fkey}_changed?") && persisted? && !send("#{fkey}_was").nil?
+            # if the ignore_tenant_changes option is present and true we'll avoid the exception because maybe an admin is making the update
+            raise ActsAsTenant::Errors::TenantIsImmutable if send("#{fkey}_changed?") && persisted? && !send("#{fkey}_was").nil? && !options[:ignore_tenant_changes]
             integer
           end
 
           define_method "#{ActsAsTenant.tenant_klass.to_s}=" do |model|
             super(model)
-            raise ActsAsTenant::Errors::TenantIsImmutable if send("#{fkey}_changed?") && persisted? && !send("#{fkey}_was").nil?
+            # if the ignore_tenant_changes option is present and true we'll avoid the exception because maybe an admin is making the update
+            raise ActsAsTenant::Errors::TenantIsImmutable if send("#{fkey}_changed?") && persisted? && !send("#{fkey}_was").nil? && !options[:ignore_tenant_changes]
             model
           end
 


### PR DESCRIPTION
In case you want to ignore tenant changes to specific models you just need to use the option:

```
ignore_tenant_changes: true
```

For example:

```
acts_as_tenant :tenant, ignore_tenant_changes: true
```
